### PR TITLE
Fix: Change repo url protocols to https to support commit hashes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,10 @@ lazy val root = (project in file("."))
 lazy val vexRiscv = RootProject(file("./ext/VexRiscv"))
 
 //For dependancies on a git : 
-//lazy val vexRiscv = RootProject(uri("git://github.com/SpinalHDL/VexRiscv.git"))
+//lazy val vexRiscv = RootProject(uri("https://github.com/SpinalHDL/VexRiscv.git"))
 
 //For dependancies on a git with a specific commit : 
-//lazy val vexRiscv = RootProject(uri("git://github.com/SpinalHDL/VexRiscv.git#commitHash"))
+//lazy val vexRiscv = RootProject(uri("https://github.com/SpinalHDL/VexRiscv.git#commitHash"))
 
 
 fork := true


### PR DESCRIPTION
It seems the git protocol does not support commit hashes via `#`.

Using HTTPS protocols fix this issue. I have updated both uri examples to HTTPS in this PR. Line 22 is still valid when using the git protocol, but I propose that for standardization reasons HTTPS protocols should provided in both examples

Resolves #1 